### PR TITLE
Fix comments Texture:{s,g}etBlendMod -> Texture:{s,g}etBlendMode

### DIFF
--- a/src/texture.c
+++ b/src/texture.c
@@ -46,7 +46,7 @@ l_texture_getAlphaMod(lua_State *L)
 }
 
 /*
- * Texture:getBlendMod()
+ * Texture:getBlendMode()
  *
  * Returns:
  *	The blend mod integer or nil on failure (SDL.blendMode)
@@ -146,7 +146,7 @@ l_texture_setAlphaMod(lua_State *L)
 }
 
 /*
- * Texture:setBlendMod(value)
+ * Texture:setBlendMode(value)
  *
  * Arguments:
  *	value the value (SDL.blendMode)


### PR DESCRIPTION
Fix code comments for Texture:{s,g}etBlendMod missing the trailing 'e' (see #15 for documentation update)