### PR TITLE
Bugfix: Surface::blit() ignored dst and src rectangles

### DIFF
--- a/common/surface.c
+++ b/common/surface.c
@@ -202,12 +202,12 @@ surfaceBlit(lua_State *L, int scaled, int lower)
 	SDL_Rect srcrect, dstrect;
 	SDL_Rect *srcptr = &srcrect, *dstptr = &dstrect;
 
- 	if (lua_type(L, 3) == LUA_TNIL) 
+	if (lua_type(L, 3) == LUA_TTABLE)
 		videoGetRect(L, 3, &srcrect);
 	else
 		SDL_GetClipRect(src, &srcrect);
 
-	if (lua_type(L, 4) == LUA_TNIL)
+	if (lua_type(L, 4) == LUA_TTABLE)
 		videoGetRect(L, 4, &dstrect);
 	else
 		SDL_GetClipRect(dst, &dstrect);


### PR DESCRIPTION
Seems to be copy-paste-typo :)