### PR TITLE
Add surface:mapRGB[A], fix number colors not having an alpha value.

### DIFF
--- a/common/surface.c
+++ b/common/surface.c
@@ -372,6 +372,40 @@ l_surface_fillRects(lua_State *L)
 }
 
 /*
+ * Surface:mapRGB()
+ *
+ * Returns:
+ * 	A Uint32 filled with the correct pixel value
+ */
+static int
+l_surface_mapRGB(lua_State *L)
+{
+	SDL_Surface *surf = commonGetAs(L, 1, SurfaceName, SDL_Surface *);
+	SDL_Color c = videoGetColorRGB(L, 2);
+
+	lua_pushinteger(L, SDL_MapRGB(surf->format, c.r, c.g, c.b));
+
+	return 1;
+}
+
+/*
+ * Surface:mapRGBA()
+ *
+ * Returns:
+ * 	A Uint32 filled with the correct pixel value.
+ */
+static int
+l_surface_mapRGBA(lua_State *L)
+{
+	SDL_Surface *surf = commonGetAs(L, 1, SurfaceName, SDL_Surface *);
+	SDL_Color c = videoGetColorRGB(L, 2);
+
+	lua_pushinteger(L, SDL_MapRGBA(surf->format, c.r, c.g, c.b, c.a));
+
+	return 1;
+}
+
+/*
  * Surface:getClipRect()
  *
  * Returns:
@@ -829,6 +863,8 @@ static const luaL_Reg methods[] = {
 	{ "convertFormat",	l_surface_convertFormat		},
 	{ "fillRect",		l_surface_fillRect		},
 	{ "fillRects",		l_surface_fillRects		},
+	{ "mapRGB", 		l_surface_mapRGB		},
+	{ "mapRGBA",		l_surface_mapRGBA		},
 	{ "getClipRect",	l_surface_getClipRect,		},
 	{ "getColorKey",	l_surface_getColorKey		},
 	{ "getAlphaMod",	l_surface_getAlphaMod		},

--- a/common/video.c
+++ b/common/video.c
@@ -200,12 +200,12 @@ videoGetColorHex(lua_State *L, int index)
 	} else if (lua_type(L, index) == LUA_TTABLE) {
 		SDL_Color tmp;
 
-		tmp.r = tableGetInt(L, index, "r");
-		tmp.g = tableGetInt(L, index, "g");
-		tmp.b = tableGetInt(L, index, "b");
-		tmp.a = tableGetInt(L, index, "a");
+		tmp.r = tableGetInt(L, index, "r") & 0xFF;
+		tmp.g = tableGetInt(L, index, "g") & 0xFF;
+		tmp.b = tableGetInt(L, index, "b") & 0xFF;
+		tmp.a = tableGetInt(L, index, "a") & 0xFF;
 
-		value = (tmp.r << 16) | (tmp.g << 8) | tmp.b;
+		value = (tmp.r << 16) | (tmp.g << 8) | tmp.b | (tmp.a << 24);
 	}
 
 	return value;
@@ -219,6 +219,7 @@ videoGetColorRGB(lua_State *L, int index)
 	if (lua_type(L, index) == LUA_TNUMBER) {
 		int value = lua_tointeger(L, index);
 
+		c.a = ((value >> 24) & 0xFF);
 		c.r = ((value >> 16) & 0xFF);
 		c.g = ((value >> 8) & 0xFF);
 		c.b = ((value) & 0xFF);


### PR DESCRIPTION
Added `surface:mapRGB` / `surface:mapRGBA` to map a color into the surface-appropriate color representation.

When passed as numbers, color channels are in the form `ARGB`, for ease of use and backwards compatibility.  Also added masking on `videoGetColorHex` so out-of-range values didn't affect the other channels.

Without these changes, integer colors passed to `renderer:setDrawColor` (and others) were loosing their alpha channel, causing havoc when used with transparent textures.