### PR TITLE
Update Version Number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ project(Lua-SDL2 C)
 # Project information
 set(MAJOR "2")
 set(MINOR "0")
-set(PATCH "4")
-set(BINDING "5")
+set(PATCH "5")
+set(BINDING "6")
 set(BINDING_PATCH "0")
 set(VERSION "${MAJOR}.${MINOR}.${PATCH}-${BINDING}.${BINDING_PATCH}")
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Lua-SDL2 (SDL2 binding for Lua)
 
 Lua-SDL2 is a pure C binding of SDL2 for Lua 5.1, Lua 5.2, Lua 5.3, and LuaJIT.
 
-The current version is 2.0.4-5.0
+The current version is 2.0.5-6.0
 
 Features
 ========


### PR DESCRIPTION
Consider yourself poked.

Also, is the binding number independent of the SDL version number, or should it be reset on each version change?  The current versioning scheme feels like the latter.