### PR TITLE
General Fixes + Refactor Color Handling

### DIFF
--- a/common/surface.c
+++ b/common/surface.c
@@ -365,8 +365,10 @@ l_surface_fillRect(lua_State *L)
 	}
 
 	/* Default color is black */
-	if (lua_gettop(L) >= 3)
-		color = videoGetColorHex(L, 3);
+	if (lua_gettop(L) >= 3) {
+		SDL_Color c = videoGetColorRGB(L, 3);
+		color = SDL_MapRGBA(surf->format, c.r, c.g, c.b, c.a);
+	}
 
 	if (SDL_FillRect(surf, rectptr, color) < 0)
 		return commonPushSDLError(L, 1);
@@ -389,7 +391,8 @@ static int
 l_surface_fillRects(lua_State *L)
 {
 	SDL_Surface *surf	= commonGetAs(L, 1, SurfaceName, SDL_Surface *);
-	Uint32 color		= videoGetColorHex(L, 3);
+	SDL_Color c		= videoGetColorRGB(L, 3);
+	Uint32 color		= SDL_MapRGBA(surf->format, c.r, c.g, c.b, c.a);
 	Array rects;
 	int ret;
 

--- a/common/video.c
+++ b/common/video.c
@@ -117,17 +117,6 @@ readTable(lua_State *L, int index, Array *array, size_t unit, TableReadFunc func
  * -------------------------------------------------------- */
 
 void
-videoPushColorRGB(lua_State *L, const SDL_Color *color)
-{
-	lua_createtable(L, 0, 4);
-
-	tableSetInt(L, -1, "r", color->r);
-	tableSetInt(L, -1, "g", color->g);
-	tableSetInt(L, -1, "b", color->b);
-	tableSetInt(L, -1, "a", color->a);
-}
-
-void
 videoPushRect(lua_State *L, const SDL_Rect *rect)
 {
 	lua_createtable(L, 4, 4);
@@ -190,14 +179,20 @@ videoGetLine(lua_State *L, int index, Line *line)
 	line->y2 = tableGetInt(L, index, "y2");
 }
 
+/*
+ * Deprecated in favor of videoGetColorRGB and SDL_MapRGBA, which enforce a
+ * common representation of color values across color tables and hexadecimal
+ * formats.
+*/
 Uint32
 videoGetColorHex(lua_State *L, int index)
 {
-	Uint32 value = 0;
+	/*Uint32 value = 0;
 
 	if (lua_type(L, index) == LUA_TNUMBER) {
 		value = lua_tointeger(L, index);
-	} else if (lua_type(L, index) == LUA_TTABLE) {
+	}
+	else if (lua_type(L, index) == LUA_TTABLE) {
 		SDL_Color tmp;
 
 		tmp.r = tableGetInt(L, index, "r") & 0xFF;
@@ -205,10 +200,13 @@ videoGetColorHex(lua_State *L, int index)
 		tmp.b = tableGetInt(L, index, "b") & 0xFF;
 		tmp.a = tableGetInt(L, index, "a") & 0xFF;
 
-		value = (tmp.r << 16) | (tmp.g << 8) | tmp.b | (tmp.a << 24);
+		value = (tmp.a << 24) | (tmp.r << 16) | (tmp.g << 8) | tmp.b;
 	}
 
-	return value;
+	return value;*/
+
+	SDL_Color c = videoGetColorRGB(L, index);
+	return c.a << 24 | c.r << 16 | c.g << 8 | c.b;
 }
 
 SDL_Color
@@ -237,6 +235,23 @@ int
 videoGetColorsRGB(lua_State *L, int index, Array *colors)
 {
 	return readTable(L, index, colors, sizeof (SDL_Color), readColors);
+}
+
+void
+videoPushColorHex(lua_State *L, const SDL_Color *c)
+{
+       lua_pushinteger(L, (c->a << 24) | (c->r << 16) | (c->g << 8) | c->b);
+}
+
+void
+videoPushColorRGB(lua_State *L, const SDL_Color *color)
+{
+       lua_createtable(L, 0, 4);
+
+       tableSetInt(L, -1, "r", color->r);
+       tableSetInt(L, -1, "g", color->g);
+       tableSetInt(L, -1, "b", color->b);
+       tableSetInt(L, -1, "a", color->a);
 }
 
 void

--- a/common/video.c
+++ b/common/video.c
@@ -187,25 +187,8 @@ videoGetLine(lua_State *L, int index, Line *line)
 Uint32
 videoGetColorHex(lua_State *L, int index)
 {
-	/*Uint32 value = 0;
-
-	if (lua_type(L, index) == LUA_TNUMBER) {
-		value = lua_tointeger(L, index);
-	}
-	else if (lua_type(L, index) == LUA_TTABLE) {
-		SDL_Color tmp;
-
-		tmp.r = tableGetInt(L, index, "r") & 0xFF;
-		tmp.g = tableGetInt(L, index, "g") & 0xFF;
-		tmp.b = tableGetInt(L, index, "b") & 0xFF;
-		tmp.a = tableGetInt(L, index, "a") & 0xFF;
-
-		value = (tmp.a << 24) | (tmp.r << 16) | (tmp.g << 8) | tmp.b;
-	}
-
-	return value;*/
-
 	SDL_Color c = videoGetColorRGB(L, index);
+
 	return c.a << 24 | c.r << 16 | c.g << 8 | c.b;
 }
 

--- a/common/video.h
+++ b/common/video.h
@@ -112,7 +112,7 @@ videoGetLine(lua_State *L, int index, Line *line);
 /**
  * Get a color from a Lua table or a hexadecimal number.
  *
- * NOTE: This method is deprecated in favor of videoGetRGB + SDL_MapRGBA.
+ * NOTE: This method is deprecated in favor of videoGetColorRGB + SDL_MapRGBA.
  *
  * @param L the Lua state
  * @param index the value index

--- a/common/video.h
+++ b/common/video.h
@@ -38,15 +38,6 @@ typedef struct line {
 } Line;
 
 /**
- * Push a SDL_Color as a table with three fields r, g, b to Lua.
- *
- * @param L the Lua state
- * @param color the color
- */
-void
-videoPushColorRGB(lua_State *L, const SDL_Color *color);
-
-/**
  * Push a SDL_Rect as a table to Lua.
  *
  * @param L the Lua state
@@ -121,6 +112,8 @@ videoGetLine(lua_State *L, int index, Line *line);
 /**
  * Get a color from a Lua table or a hexadecimal number.
  *
+ * NOTE: This method is deprecated in favor of videoGetRGB + SDL_MapRGBA.
+ *
  * @param L the Lua state
  * @param index the value index
  * @return the color as hexadecimal
@@ -148,6 +141,24 @@ videoGetColorRGB(lua_State *L, int index);
  */
 int
 videoGetColorsRGB(lua_State *L, int index, Array *colors);
+
+/**
+ * Push a SDL_Color as a table with three fields r, g, b to Lua.
+ *
+ * @param L the Lua state
+ * @param color the color
+ */
+void
+videoPushColorRGB(lua_State *L, const SDL_Color *color);
+
+/**
+ * Push a SDL_Color as a hexadecimal integer in ARGB8888 format to Lua.
+ *
+ * @param L the Lua state
+ * @param color the color
+ */
+void
+videoPushColorRGB(lua_State *L, const SDL_Color *color);
 
 /**
  * Get a SDL_DisplayMode from a Lua table. Raises an error if

--- a/common/video.h
+++ b/common/video.h
@@ -158,7 +158,7 @@ videoPushColorRGB(lua_State *L, const SDL_Color *color);
  * @param color the color
  */
 void
-videoPushColorRGB(lua_State *L, const SDL_Color *color);
+videoPushColorHex(lua_State *L, const SDL_Color *color);
 
 /**
  * Get a SDL_DisplayMode from a Lua table. Raises an error if

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -233,8 +233,8 @@ l_clearHints(lua_State *L)
 static int
 l_getHint(lua_State *L)
 {
-	const char *name = luaL_checkstring(L, 1);
-	const char *value = SDL_GetHint(name);
+	const char *name	= luaL_checkstring(L, 1);
+	const char *value	= SDL_GetHint(name);
 
 	if (value == NULL)
 		lua_pushnil(L);
@@ -262,19 +262,20 @@ l_getHint(lua_State *L)
 static int
 l_getHintBoolean(lua_State *L)
 {
-	const char *name = luaL_checkstring(L, 1);
-	int val = lua_toboolean(L, 2);
+	const char *name	= luaL_checkstring(L, 1);
+	int val			= lua_toboolean(L, 2);
 
 	return commonPush(L, "b", SDL_GetHintBoolean(name, val));
 }
 #endif
 
 /*
- * SDL.setHint(name, value)
+ * SDL.setHint(name, value, priority)
  *
  * Arguments:
  *	name the hint name
  *	value the hint value
+ *	priority the hint priority - defaults to SDL.hintPriority.Normal.
  *
  * Returns:
  *	True on success or false
@@ -283,10 +284,11 @@ l_getHintBoolean(lua_State *L)
 static int
 l_setHint(lua_State *L)
 {
-	const char *name	= luaL_checkstring(L, 1);
-	const char *value	= luaL_checkstring(L, 2);
+	const char *name		= luaL_checkstring(L, 1);
+	const char *value		= luaL_checkstring(L, 2);
+	const SDL_HintPriority priority	= luaL_optinteger(L, 3, SDL_HINT_DEFAULT);
 
-	return commonPush(L, "b", SDL_SetHint(name, value));
+	return commonPush(L, "b", SDL_SetHintWithPriority(name, value, priority));
 }
 
 /*

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -215,7 +215,7 @@ l_getRelativeMouseState(lua_State *L)
 	lua_pushinteger(L, x);
 	lua_pushinteger(L, y);
 
-	return 0;
+	return 3;
 }
 
 /*

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -627,14 +627,11 @@ l_renderer_getDrawColor(lua_State *L)
 {
 	SDL_Renderer *rd = commonGetAs(L, 1, RendererName, SDL_Renderer *);
 	SDL_Color c;
-	Uint32 value;
 
 	if (SDL_GetRenderDrawColor(rd, &c.r, &c.g, &c.b, &c.a) < 0)
 		return commonPushSDLError(L, 2);
 
-	value = (c.a << 24) | (c.r << 16) | (c.g << 8) | c.b;
-
-	commonPush(L, "i", value);
+	videoPushColorHex(L, &c);
 	videoPushColorRGB(L, &c);
 
 	return 2;

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -632,7 +632,7 @@ l_renderer_getDrawColor(lua_State *L)
 	if (SDL_GetRenderDrawColor(rd, &c.r, &c.g, &c.b, &c.a) < 0)
 		return commonPushSDLError(L, 2);
 
-	value = (c.r << 16) | (c.g << 8) | c.b;
+	value = (c.a << 24) | (c.r << 16) | (c.g << 8) | c.b;
 
 	commonPush(L, "i", value);
 	videoPushColorRGB(L, &c);

--- a/tutorials/06-text/tutorial.lua
+++ b/tutorials/06-text/tutorial.lua
@@ -21,17 +21,18 @@ trySDL(ttf.init)
 -- Create the window
 local win = trySDL(SDL.createWindow, {
 	title	= "06 - Drawing text",		-- optional
-	width	= 90,				-- optional
-	height	= 50,				-- optional
+	width	= 160,				-- optional
+	height	= 80,				-- optional
 })
 
 -- Create the renderer
 local rdr = trySDL(SDL.createRenderer, win, -1)
 
 -- Open the font
-local font = trySDL(ttf.open, "DejaVuSans.ttf", 10)
+local font = trySDL(ttf.open, "DejaVuSans.ttf", 24)
 
 -- Create some text
+local w, h = trySDL(font.sizeText, "Lua-SDL2", t)
 local s = trySDL(font.renderUtf8, font, "Lua-SDL2", "solid", 0xFFFFFF)
 
 -- Convert to texture and show
@@ -39,7 +40,15 @@ local text = trySDL(rdr.createTextureFromSurface, rdr, s)
 
 for i = 1, 50 do
 	rdr:clear()
-	rdr:copy(text)
+
+	-- If a rectangle is not specified, it defaults to the clipping rectangle
+	-- of the source or destination, respectively.
+	if i%20 < 10 then
+		rdr:copy(text)
+	else
+		rdr:copy(text, nil, {x=0, y=0, w=w, h=h})
+	end
+
 	rdr:present()
 
 	SDL.delay(100)

--- a/tutorials/07-bouncing/tutorial.lua
+++ b/tutorials/07-bouncing/tutorial.lua
@@ -9,6 +9,7 @@ local running	= true
 local graphics	= { }
 local pos	= { }
 local dir	= { 1, 1 }
+local velocity	= 2
 local width	= 640
 local height	= 480
 
@@ -78,19 +79,18 @@ while running do
 	graphics.rdr:copy(graphics.logo, nil, pos)
 	graphics.rdr:present()
 
-	pos.x = pos.x + dir[1]
-	pos.y = pos.y + dir[2]
+	pos.x = pos.x + dir[1] * velocity
+	pos.y = pos.y + dir[2] * velocity
 
-	if dir[1] > 0 and pos.x > width - 256 then
-		dir[1] = -1
-	elseif dir[1] < 0 and pos.x <= 0 then
-		dir[1] = 1
+	-- When we hit a wall, bounce.
+	if (dir[1] > 0 and pos.x > width - 256)
+	or (dir[1] < 0 and pos.x <= 0) then
+		dir[1] = -dir[1]
 	end
 
-	if dir[2] > 0 and pos.y > height - 256 then
-		dir[2] = -1
-	elseif dir[2] < 0 and pos.y <= 0 then
-		dir[2] = 1
+	if (dir[2] > 0 and pos.y > height - 256)
+	or (dir[2] < 0 and pos.y <= 0) then
+		dir[2] = -dir[2]
 	end
 
 	SDL.delay(20)


### PR DESCRIPTION
Couple of fixes / minor features:
* getRelativeMouseState was returning nothing
* We now have support for SDL_SetHintWithPriority, via an optional param in SDL.setHint()
* Minor updates on a couple of tutorials
* Code using libcommon can now push hex colors to Lua with `videoPushColorHex`

I unified how the library takes colors from Lua code, and deprecated `videoGetColorHex`.
In theory, _all_ hex-encoded values taken from Lua are interpreted as ARGB8888, without user code having to do anything.

The only place where `videoGetColorHex` was being used was in `surface:fillRect`/`surface:fillRects`, and there's handy access to `SDL_MapRGBA()` and the needed pixel format pointer there.