### PR TITLE
added SDL.createSystemCursor function and SDL.systemCursor enum

### DIFF
--- a/src/SDL.c
+++ b/src/SDL.c
@@ -458,6 +458,7 @@ static const struct {
 	{ &Haptic						},
 	{ &TimerObject						},
 	{ &GlObject						},
+	{ &MouseCursor						},
 	{ NULL							}
 };
 

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -404,6 +404,7 @@ static const struct {
 	/* General */
 	{ "flags",		InitFlags			},
 
+	{ "systemCursor",	SystemCursor			},
 	{ "mouseButton",	MouseButtons			},
 	{ "mouseMask",		MouseMask			},
 #if SDL_VERSION_ATLEAST(2, 0, 2)

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -84,8 +84,8 @@ static int
 l_createColorCursor(lua_State *L)
 {
 	SDL_Surface *s	= commonGetAs(L, 1, SurfaceName, SDL_Surface *);
-	int hot_x	= luaL_checkinteger(L, 1);
-	int hot_y	= luaL_checkinteger(L, 2);
+	int hot_x	= luaL_checkinteger(L, 2);
+	int hot_y	= luaL_checkinteger(L, 3);
 	SDL_Cursor *c;
 
 	c = SDL_CreateColorCursor(s, hot_x, hot_y);

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -46,6 +46,29 @@ l_captureMouse(lua_State *L)
 #endif
 
 /*
+ * SDL.createSystemCursor(id)
+ *
+ * Arguments:
+ *	id the cursor id
+ *
+ * Returns:
+ *	A cursor object or nil on failure
+ *	The error message
+ */
+static int
+l_createSystemCursor(lua_State *L)
+{
+	int id	= luaL_checkinteger(L, 1);
+	SDL_Cursor *c;
+
+	c = SDL_CreateSystemCursor(id);
+	if (c == NULL)
+		return commonPushSDLError(L, 1);
+
+	return commonPush(L, "p", MouseCursorName, c);
+}
+
+/*
  * SDL.createColorCursor(s, x, y)
  *
  * Arguments:
@@ -296,6 +319,7 @@ const luaL_Reg MouseFunctions[] = {
 #if SDL_VERSION_ATLEAST(2, 0, 4)
 	{ "captureMouse",		l_captureMouse		},
 #endif
+	{ "createSystemCursor",		l_createSystemCursor	},
 	{ "createColorCursor",		l_createColorCursor	},
 	{ "createCursor",		l_createCursor		},
 	{ "getCursor",			l_getCursor		},
@@ -337,6 +361,25 @@ const CommonObject MouseCursor = {
 	"Cursor",
 	NULL,
 	metamethods
+};
+
+/*
+ * SDL.systemCursor
+ */
+const CommonEnum SystemCursor[] = {
+	{ "Arrow",			SDL_SYSTEM_CURSOR_ARROW		},
+	{ "Ibeam",			SDL_SYSTEM_CURSOR_IBEAM		},
+	{ "Wait",			SDL_SYSTEM_CURSOR_WAIT		},
+	{ "Crosshair",			SDL_SYSTEM_CURSOR_CROSSHAIR	},
+	{ "WaitArrow",			SDL_SYSTEM_CURSOR_WAITARROW	},
+	{ "SizeNWSE",			SDL_SYSTEM_CURSOR_SIZENWSE	},
+	{ "SizeNESW",			SDL_SYSTEM_CURSOR_SIZENESW	},
+	{ "SizeWE",			SDL_SYSTEM_CURSOR_SIZEWE	},
+	{ "SizeNS",			SDL_SYSTEM_CURSOR_SIZENS	},
+	{ "SizeAll",			SDL_SYSTEM_CURSOR_SIZEALL	},
+	{ "No",				SDL_SYSTEM_CURSOR_NO		},
+	{ "Hand",			SDL_SYSTEM_CURSOR_HAND		},
+	{ NULL,				-1				},
 };
 
 /*

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -28,6 +28,8 @@ extern const luaL_Reg MouseFunctions[];
 
 extern const CommonObject MouseCursor;
 
+extern const CommonEnum SystemCursor[];
+
 extern const CommonEnum MouseButtons[];
 
 extern const CommonEnum MouseMask[];


### PR DESCRIPTION
Noticed this function was missing so added it in

https://wiki.libsdl.org/SDL_CreateSystemCursor

Please double check that the capitalisation of the enums is as expected.

...also noticed that MouseCursor was not registered so setting the cursor was never actually possible.

and l_createColorCursor reads its arguments slightly wrong