### PR TITLE
fix warning gcc 6.3.1

### DIFF
--- a/common/surface.c
+++ b/common/surface.c
@@ -891,7 +891,7 @@ l_surface_getRawPixel(lua_State *L)
 	int x = luaL_checkinteger(L, 2);
 	int y = luaL_checkinteger(L, 3);
 	int size = surf->format->BytesPerPixel;
-	Uint8 *ptr = (Uint8 *)surf->pixels + y * surf->pitch + x * size;
+	char *ptr = (char *)surf->pixels + y * surf->pitch + x * size;
 	lua_pushlstring(L, ptr, size);
 	return 1;
 }


### PR DESCRIPTION
```
/home/user/build/linaro/build/lua-sdl2-v2.0.5-6.0/common/surface.c: In function 'l_surface_getRawPixel':
/home/user/build/linaro/build/lua-sdl2-v2.0.5-6.0/common/surface.c:892:21: warning: pointer targets in passing argument 2 of 'lua_pushlstring' differ in signedness [-Wpointer-sign]
  lua_pushlstring(L, ptr, size);
                     ^~~
In file included from /home/user/build/linaro/build/lua-sdl2-v2.0.5-6.0/common/common.h:25:0,
                 from /home/user/build/linaro/build/lua-sdl2-v2.0.5-6.0/common/rwops.h:22,
                 from /home/user/build/linaro/build/lua-sdl2-v2.0.5-6.0/common/surface.c:24:
/home/user/build/linaro/host/usr/arm-buildroot-linux-gnueabihf/sysroot/usr/include/lua.h:227:22: note: expected 'const char *' but argument is of type 'Uint8 * {aka unsigned char *}'
 LUA_API const char *(lua_pushlstring) (lua_State *L, const char *s, size_t len);
                      ^~~~~~~~~~~~~~~
```