### PR TITLE
fixed incorrect `SDL.mouseMask.Middle` value

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -400,7 +400,7 @@ const CommonEnum MouseButtons[] = {
 const CommonEnum MouseMask[] = {
 	{ "Left",			SDL_BUTTON_LMASK	},
 	{ "Right",			SDL_BUTTON_RMASK	},
-	{ "Middle",			SDL_BUTTON_RMASK	},
+	{ "Middle",			SDL_BUTTON_MMASK	},
 	{ "X1",				SDL_BUTTON_X1MASK	},
 	{ "X2",				SDL_BUTTON_X2MASK	},
 	{ NULL,				-1			},


### PR DESCRIPTION
fixed incorrect value of `SDL.mouseMask.Middle` inside `src/mouse.c`.
See Issue #72 for more information.