### PR TITLE
Fix: correct rwops read argument and return value

### DIFF
--- a/common/rwops.c
+++ b/common/rwops.c
@@ -59,15 +59,15 @@ rw_seek(SDL_RWops *ops, Sint64 offset, int whence)
 }
 
 static size_t
-rw_read(SDL_RWops *ops, void *dst, size_t num, size_t size)
+rw_read(SDL_RWops *ops, void *dst, size_t size, size_t num)
 {
 	Funcs *opsref	= ops->hidden.unknown.data1;
 	lua_State *L	= ops->hidden.unknown.data2;
-	int nread	= 0;
+	int nbytes	= 0;
 
 	lua_rawgeti(L, LUA_REGISTRYINDEX, opsref->read);
-	lua_pushinteger(L, num);
 	lua_pushinteger(L, size);
+	lua_pushinteger(L, num);
 	lua_call(L, 2, 2);
 
 	/* Use the content as a string */
@@ -75,15 +75,15 @@ rw_read(SDL_RWops *ops, void *dst, size_t num, size_t size)
 		const char *data;
 
 		/* Retrieve length or 0 on error or EOF */
-		nread = lua_tointeger(L, -1);
+		nbytes = lua_tointeger(L, -1);
 
-		if (nread != EOF && nread > 0) {
+		if (nbytes != EOF && nbytes > 0) {
 			data = lua_tostring(L, -2);
-			memcpy(dst, data, nread);
+			memcpy(dst, data, nbytes);
 		}
 	}
 
-	return nread;
+	return nbytes / size;
 }
 
 static size_t


### PR DESCRIPTION
As per https://github.com/Tangent128/luasdl2/wiki/Sdl-RWCreate, The Lua API for LuaSDL expects the Lua callback to have as inputs:

* `num` - number of entries to read
* `size` - size of each entry

and it expects two returns

* a string with raw bytes
* and the size in bytes.

However, as per `/usr/include/SDL2/SDL_rwops.h`, the C API for SDL is different: it expects the C callback to use input arguments in reverse order:

* `ops` - the RWops object
* `dst` - output buffer
* `size` - size of each entry
* `num` - number of entries to read

and it expects a different return:

* the number of _items_ read

When `size` is different than 1, the number of items and bytes don't match. This causes problems when trying to use `mixer.loadWAV_RW`, which does perform calls with `size` greater than 1.

This commits fixes the behavior of the callback created via Lua.

Since this operation only ever worked correctly when size was 1, reversing the argument order declaration to match the C library is not a compatibility issue -- this just reflects correctly how the function really works.