### PR TITLE
Fix getRelativeMouseMode()

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -215,7 +215,7 @@ l_getMouseState(lua_State *L)
 static int
 l_getRelativeMouseMode(lua_State *L)
 {
-	return commonPush(L, "b", SDL_GetRelativeMouseMode() == 0);
+	return commonPush(L, "b", SDL_GetRelativeMouseMode() == SDL_TRUE);
 }
 
 /*


### PR DESCRIPTION
Hello. This patch fixes getRelativeMouseMode() (there must be a comparison with SDL_TRUE, not 0)